### PR TITLE
feat: Migrate Tandem API Test Bed to OAuth Authorization Code flow wi…

### DIFF
--- a/env.js
+++ b/env.js
@@ -5,7 +5,7 @@ const stgEnvironment = {
   name: "stg",
   oxygenHost: "https://accounts-staging.autodesk.com",
   forgeHost: "https://developer-stg.api.autodesk.com",
-  forgeKey: "hZy6ABuq8STldhv3X6IDrgyXUOVZZHtW", // TODO: Replace with your Forge Key to develop locally
+  forgeKey: "dfPQL99PtzJAtw7jakGTSD1tuFcUMl33JwsgF0xamdiMp0M8", // TODO: Replace with your Forge Key to develop locally
   loginRedirect: "http://localhost:8000",
   tandemDbBaseURL: "https://tandem-stg.autodesk.com/api/v1",
   tandemAppBaseURL: "https://tandem-stg.autodesk.com/app",
@@ -16,7 +16,7 @@ const prodEnvironment = {
   name: "prod",
   oxygenHost: "https://accounts.autodesk.com",
   forgeHost: "https://developer.api.autodesk.com",
-  forgeKey: "krVjl7bmgBR47lo9g3U1FAjeUkfmD4w7", // TODO: Replace with your Forge Key to develop locally
+  forgeKey: "dfPQL99PtzJAtw7jakGTSD1tuFcUMl33JwsgF0xamdiMp0M8", // TODO: Replace with your Forge Key to develop locally
   loginRedirect: "http://localhost:8000",
   tandemDbBaseURL: "https://tandem.autodesk.com/api/v1",
   tandemAppBaseURL: "https://tandem.autodesk.com/app",

--- a/env.js
+++ b/env.js
@@ -5,7 +5,7 @@ const stgEnvironment = {
   name: "stg",
   oxygenHost: "https://accounts-staging.autodesk.com",
   forgeHost: "https://developer-stg.api.autodesk.com",
-  forgeKey: "dfPQL99PtzJAtw7jakGTSD1tuFcUMl33JwsgF0xamdiMp0M8", // TODO: Replace with your Forge Key to develop locally
+  forgeKey: "krVjl7bmgBR47lo9g3U1FAjeUkfmD4w7", // TODO: Replace with your Forge Key to develop locally
   loginRedirect: "http://localhost:8000",
   tandemDbBaseURL: "https://tandem-stg.autodesk.com/api/v1",
   tandemAppBaseURL: "https://tandem-stg.autodesk.com/app",
@@ -16,7 +16,7 @@ const prodEnvironment = {
   name: "prod",
   oxygenHost: "https://accounts.autodesk.com",
   forgeHost: "https://developer.api.autodesk.com",
-  forgeKey: "dfPQL99PtzJAtw7jakGTSD1tuFcUMl33JwsgF0xamdiMp0M8", // TODO: Replace with your Forge Key to develop locally
+  forgeKey: "krVjl7bmgBR47lo9g3U1FAjeUkfmD4w7", // TODO: Replace with your Forge Key to develop locally
   loginRedirect: "http://localhost:8000",
   tandemDbBaseURL: "https://tandem.autodesk.com/api/v1",
   tandemAppBaseURL: "https://tandem.autodesk.com/app",

--- a/server.py
+++ b/server.py
@@ -1,0 +1,60 @@
+import os
+import requests
+from flask import Flask, send_from_directory, request, redirect, session, jsonify
+
+from dotenv import load_dotenv
+load_dotenv()
+
+app = Flask(__name__, static_folder='.', static_url_path='')
+app.secret_key = os.environ.get('FLASK_SECRET_KEY', 'dev_secret_key')  # Change for production
+
+# Configuration - load from .env
+FORGE_CLIENT_ID = os.environ.get('FORGE_CLIENT_ID')
+FORGE_CLIENT_SECRET = os.environ.get('FORGE_CLIENT_SECRET')
+REDIRECT_URI = os.environ.get('FORGE_REDIRECT_URI', 'http://localhost:5000/oauth/callback')
+
+@app.route('/')
+def index():
+    return send_from_directory('.', 'index.html')
+
+@app.route('/<path:path>')
+def static_proxy(path):
+    # Serve static files and directories
+    return send_from_directory('.', path)
+
+@app.route('/oauth/callback')
+def oauth_callback():
+    code = request.args.get('code')
+    if not code:
+        return 'Missing code', 400
+
+    # Exchange code for access token
+    token_url = 'https://developer.api.autodesk.com/authentication/v2/token'
+    data = {
+        'client_id': FORGE_CLIENT_ID,
+        'client_secret': FORGE_CLIENT_SECRET,
+        'grant_type': 'authorization_code',
+        'code': code,
+        'redirect_uri': REDIRECT_URI
+    }
+    headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+    resp = requests.post(token_url, data=data, headers=headers)
+    if resp.status_code != 200:
+        return f"Token exchange failed: {resp.text}", 400
+
+    token_data = resp.json()
+    # Store token in session (or return to frontend as needed)
+    session['access_token'] = token_data.get('access_token')
+    # Redirect to home page (or wherever appropriate)
+    return redirect('/')
+
+@app.route('/api/token')
+def get_token():
+    # Endpoint for frontend to retrieve access token if needed
+    token = session.get('access_token')
+    if not token:
+        return jsonify({'error': 'Not authenticated'}), 401
+    return jsonify({'access_token': token})
+
+if __name__ == '__main__':
+    app.run(port=5000, debug=True)


### PR DESCRIPTION
…th Flask backend

- Replaced deprecated Implicit Grant (response_type=token) with Authorization Code flow (response_type=code) for Autodesk Forge/APS OAuth.
- Added a minimal Flask backend (server.py) to handle OAuth code exchange and serve static files.
- Integrated python-dotenv to securely load Forge Client ID, Client Secret, and Flask secret key from a .env file.
- Updated login.js to use the new OAuth flow and fetch the access token from the backend on every page load.
- Improved login state detection and session management in the frontend.
- Updated documentation and configuration to support secure local development.
- Output for API requests remains in the browser console as per the original test bed design.

BREAKING CHANGE: You must now configure a .env file with your Forge credentials and run the Flask server for local development.

Note: Do NOT commit your .env file if it contains secrets.