### PR TITLE
Add profapi:img-profile:read scope for Profile API v2 migration

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -67,7 +67,7 @@ async function doRedirection(clientId, scope) {
  * Initiate login flow
  */
 export async function login() {
-  const scope = 'data:read data:write user-profile:read';
+  const scope = 'data:read data:write user-profile:read profapi:img-profile:read';
   await doRedirection(env.apsKey, scope);
 }
 


### PR DESCRIPTION
APS identity is enforcing granular resource-specific scopes for the User Profile API (v2). Add profapi:img-profile:read since the app accesses the picture field from the userinfo endpoint.

Made-with: Cursor